### PR TITLE
feat(notion-to-jsx): ToC scrollOffset prop 추가

### DIFF
--- a/packages/notion-to-jsx/src/components/Renderer/index.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/index.tsx
@@ -18,6 +18,7 @@ import { darkTheme, lightTheme } from '../../styles/theme.css';
 
 export interface TocStyleOptions {
   top?: string;
+  scrollOffset?: number;
 }
 
 interface Props {
@@ -129,7 +130,7 @@ const Renderer = memo(
             className={`${theme} ${tocWrapper}`}
             style={tocStyle?.top ? { top: tocStyle.top } : undefined}
           >
-            <TableOfContents headings={headings} />
+            <TableOfContents headings={headings} scrollOffset={tocStyle?.scrollOffset} />
           </div>
         )}
       </>

--- a/packages/notion-to-jsx/src/components/TableOfContents/index.tsx
+++ b/packages/notion-to-jsx/src/components/TableOfContents/index.tsx
@@ -19,6 +19,7 @@ import {
 
 export interface TableOfContentsProps {
   headings: HeadingItem[];
+  scrollOffset?: number;
 }
 
 const lineLevelStyles = {
@@ -46,7 +47,7 @@ const menuLevelStyles = {
  * <TableOfContents headings={headings} />
  * ```
  */
-const TableOfContents = memo(({ headings }: TableOfContentsProps) => {
+const TableOfContents = memo(({ headings, scrollOffset = 0 }: TableOfContentsProps) => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -95,10 +96,13 @@ const TableOfContents = memo(({ headings }: TableOfContentsProps) => {
                 className={`${menuLink} ${menuLevelStyles[heading.level]} ${activeId === heading.id ? menuLinkActive : ''}`}
                 onClick={(e) => {
                   e.preventDefault();
-                  document.getElementById(heading.id)?.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start',
-                  });
+                  const el = document.getElementById(heading.id);
+                  if (el) {
+                    window.scrollTo({
+                      top: el.offsetTop - scrollOffset,
+                      behavior: 'smooth',
+                    });
+                  }
                 }}
               >
                 {heading.text}


### PR DESCRIPTION
## 변경 사항
- `TocStyleOptions`에 `scrollOffset` prop 추가
- sticky header 등 고정 요소가 있을 때 스크롤 위치 오프셋 지정 가능

## 사용법
```tsx
<Renderer
  blocks={blocks}
  showToc
  tocStyle={{ top: '20%', scrollOffset: 60 }}
/>
```

## 변경된 파일
- `Renderer/index.tsx` - TocStyleOptions에 scrollOffset 추가
- `TableOfContents/index.tsx` - scrollOffset 적용하여 window.scrollTo 사용