### PR TITLE
docs: 루트 및 패키지 README 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
 # notion-to-jsx
+
+[![npm version](https://img.shields.io/npm/v/notion-to-jsx.svg)](https://www.npmjs.com/package/notion-to-jsx)
+[![npm version](https://img.shields.io/npm/v/notion-to-utils.svg?label=notion-to-utils)](https://www.npmjs.com/package/notion-to-utils)
+[![license](https://img.shields.io/npm/l/notion-to-jsx.svg)](https://github.com/01-binary/notion-to-jsx/blob/main/LICENSE)
+
+Notion 페이지를 React 컴포넌트로 렌더링하는 풀스택 솔루션입니다. 공식 Notion API로 데이터를 가져오고, JSX로 렌더링합니다.
+
+## Features
+
+- **공식 Notion API** 기반 — `@notionhq/client` 확장
+- **자동 메타데이터 주입** — 이미지 크기, 북마크 OG 데이터를 페칭 시 자동 처리
+- **18개 블록 타입** 지원 — 텍스트, 리스트, 이미지, 코드, 테이블, 토글, 비디오, 임베드 등
+- **다크 모드 / 목차** — 내장 테마와 자동 생성 목차
+- **Zero-runtime CSS** — Vanilla Extract 기반 스타일링
+
+## Packages
+
+| 패키지 | 설명 | 버전 |
+|--------|------|------|
+| [notion-to-utils](./packages/notion-to-utils) | Notion API 래퍼 (데이터 페칭) | [![npm](https://img.shields.io/npm/v/notion-to-utils.svg)](https://www.npmjs.com/package/notion-to-utils) |
+| [notion-to-jsx](./packages/notion-to-jsx) | Notion 블록 React 렌더러 | [![npm](https://img.shields.io/npm/v/notion-to-jsx.svg)](https://www.npmjs.com/package/notion-to-jsx) |
+
+## Quick Start
+
+### 1. 설치
+
+```bash
+pnpm add notion-to-utils notion-to-jsx react react-dom
+```
+
+### 2. 데이터 페칭 (서버)
+
+```typescript
+import Client from 'notion-to-utils';
+
+const client = new Client({ auth: process.env.NOTION_TOKEN });
+
+const blocks = await client.getPageBlocks('page-id');
+const props = await client.getPageProperties('page-id');
+```
+
+### 3. 렌더링 (클라이언트)
+
+```tsx
+import { Renderer } from 'notion-to-jsx';
+
+export default function NotionPage({ blocks, title, cover }) {
+  return (
+    <Renderer
+      blocks={blocks}
+      title={title}
+      cover={cover}
+      isDarkMode={false}
+    />
+  );
+}
+```
+
+## 지원 블록 타입
+
+| 카테고리 | 블록 |
+|----------|------|
+| 텍스트 | Paragraph, Heading 1/2/3, Quote |
+| 리스트 | Bulleted List, Numbered List |
+| 미디어 | Image, Video, Bookmark, Embed, Link Preview |
+| 코드 | Code (구문 하이라이팅) |
+| 구조 | Table, Toggle, Column |
+
+## Contributing
+
+```bash
+git clone https://github.com/01-binary/notion-to-jsx.git
+cd notion-to-jsx
+pnpm install
+pnpm dev
+```
+
+## 라이선스
+
+MIT

--- a/packages/notion-to-jsx/README.md
+++ b/packages/notion-to-jsx/README.md
@@ -1,0 +1,83 @@
+# notion-to-jsx
+
+[![npm version](https://img.shields.io/npm/v/notion-to-jsx.svg)](https://www.npmjs.com/package/notion-to-jsx)
+[![license](https://img.shields.io/npm/l/notion-to-jsx.svg)](https://github.com/01-binary/notion-to-jsx/blob/main/LICENSE)
+
+Notion 블록을 React JSX 컴포넌트로 렌더링하는 라이브러리입니다. 다크 모드, 목차, 코드 하이라이팅을 지원합니다.
+
+## 설치
+
+```bash
+pnpm add notion-to-jsx react react-dom
+```
+
+## 사용법
+
+[notion-to-utils](https://www.npmjs.com/package/notion-to-utils)로 가져온 블록 데이터를 `Renderer`에 전달합니다.
+
+```tsx
+import { Renderer } from 'notion-to-jsx';
+import type { NotionBlock } from 'notion-to-jsx';
+
+interface Props {
+  blocks: NotionBlock[];
+  title: string;
+  cover: string;
+}
+
+export default function NotionPage({ blocks, title, cover }: Props) {
+  return (
+    <Renderer
+      blocks={blocks}
+      title={title}
+      cover={cover}
+      isDarkMode={false}
+      showToc={true}
+      tocStyle={{ top: '80px', scrollOffset: 100 }}
+    />
+  );
+}
+```
+
+## Props
+
+| Prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `blocks` | `NotionBlock[]` | (필수) | Notion 블록 배열 |
+| `title` | `string` | - | 페이지 제목 |
+| `cover` | `string` | - | 커버 이미지 URL |
+| `isDarkMode` | `boolean` | `false` | 다크 모드 활성화 |
+| `showToc` | `boolean` | `true` | 목차 표시 여부 |
+| `tocStyle` | `TocStyleOptions` | - | 목차 스타일 옵션 |
+
+### TocStyleOptions
+
+```typescript
+interface TocStyleOptions {
+  top?: string;        // 목차 상단 위치 (CSS top 값)
+  scrollOffset?: number; // 헤딩 클릭 시 스크롤 오프셋 (px)
+}
+```
+
+## 지원 블록 타입
+
+- **텍스트**: Paragraph, Heading 1/2/3, Quote
+- **리스트**: Bulleted List, Numbered List
+- **미디어**: Image, Video, Bookmark, Embed, Link Preview
+- **코드**: Code (구문 하이라이팅)
+- **구조**: Table, Toggle, Column
+- **기타**: Cover, Title, Table of Contents
+
+## 타입
+
+```typescript
+import type { NotionBlock, TocStyleOptions } from 'notion-to-jsx';
+```
+
+## 관련 패키지
+
+- [notion-to-utils](https://www.npmjs.com/package/notion-to-utils) - Notion API 래퍼 (데이터 페칭)
+
+## 라이선스
+
+MIT

--- a/packages/notion-to-utils/README.md
+++ b/packages/notion-to-utils/README.md
@@ -1,5 +1,8 @@
 # notion-to-utils
 
+[![npm version](https://img.shields.io/npm/v/notion-to-utils.svg)](https://www.npmjs.com/package/notion-to-utils)
+[![license](https://img.shields.io/npm/l/notion-to-utils.svg)](https://github.com/01-binary/notion-to-jsx/blob/main/LICENSE)
+
 Notion API 래퍼 라이브러리입니다. 블록/속성 조회 시 이미지 메타데이터와 북마크 OG 데이터를 자동으로 처리합니다.
 
 ## 설치
@@ -99,6 +102,10 @@ const url = formatNotionImageUrl(
 ```typescript
 import type { NotionBlock } from 'notion-to-utils';
 ```
+
+## 관련 패키지
+
+- [notion-to-jsx](https://www.npmjs.com/package/notion-to-jsx) - Notion 블록 React 렌더러
 
 ## 라이선스
 

--- a/packages/notion-types/README.md
+++ b/packages/notion-types/README.md
@@ -1,0 +1,70 @@
+# notion-types
+
+`notion-to-jsx`와 `notion-to-utils`에서 공유하는 타입 정의 패키지입니다.
+
+> **Private 패키지**: 워크스페이스 내부에서만 사용됩니다.
+
+## 타입
+
+### NotionBlock
+
+모든 블록 타입의 유니온 타입입니다.
+
+```typescript
+import type { NotionBlock } from 'notion-types';
+```
+
+지원하는 블록 타입:
+
+| 타입 | 인터페이스 |
+|------|-----------|
+| `paragraph` | `ParagraphBlock` |
+| `heading_1` | `Heading1Block` |
+| `heading_2` | `Heading2Block` |
+| `heading_3` | `Heading3Block` |
+| `code` | `CodeBlock` |
+| `image` | `ImageBlock` |
+| `bookmark` | `BookmarkBlock` |
+| `table` | `TableBlock` |
+| `table_row` | `TableRowBlock` |
+| `quote` | `QuoteBlock` |
+| `toggle` | `ToggleBlock` |
+| `bulleted_list_item` | `BulletedListItemBlock` |
+| `numbered_list_item` | `NumberedListItemBlock` |
+| `column_list` | `ColumnListBlock` |
+| `column` | `ColumnBlock` |
+| `video` | `VideoBlock` |
+| `embed` | `EmbedBlock` |
+| `link_preview` | `LinkPreviewBlock` |
+
+### RichTextItem
+
+Notion 리치 텍스트 항목입니다. 텍스트 서식(bold, italic, underline, strikethrough, code, color)과 링크 정보를 포함합니다.
+
+```typescript
+import type { RichTextItem } from 'notion-types';
+```
+
+### OpenGraphData
+
+북마크 블록의 OG 메타데이터입니다.
+
+```typescript
+import type { OpenGraphData } from 'notion-types';
+
+// { title, description, image, siteName, url, favicon? }
+```
+
+### ImageFormatMetadata
+
+이미지 블록의 크기 메타데이터입니다.
+
+```typescript
+import type { ImageFormatMetadata } from 'notion-types';
+
+// { block_width, block_height, block_aspect_ratio }
+```
+
+## 라이선스
+
+MIT


### PR DESCRIPTION
## 변경 사항

- 루트 README 작성 (프로젝트 소개, Features, Quick Start, 지원 블록 타입, Contributing)
- `notion-to-jsx` README 작성 (설치, 사용법, Props, 지원 블록 타입)
- `notion-types` README 작성 (타입 정의 목록)
- `notion-to-utils` README 개선 (npm 배지, 관련 패키지 링크 추가)

## 변경된 파일

- `README.md` — 루트 README 신규 작성
- `packages/notion-to-jsx/README.md` — 신규
- `packages/notion-types/README.md` — 신규
- `packages/notion-to-utils/README.md` — 배지, 관련 패키지 섹션 추가