### PR TITLE
refactor(notion-to-jsx): 타입 안전성 강화, Props 전달 컨벤션 통일

### DIFF
--- a/.changeset/slow-cars-wait.md
+++ b/.changeset/slow-cars-wait.md
@@ -1,0 +1,5 @@
+---
+"notion-to-jsx": patch
+---
+
+타입 안전성 강화, Props 전달 컨벤션 통일

--- a/packages/notion-to-jsx/src/components/Cover/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Cover/styles.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+export { skeletonWrapper } from '../../styles/loadingOverlay.css';
 
 export const coverContainer = style({
   position: 'relative',
@@ -15,31 +16,6 @@ export const coverContainer = style({
       borderRadius: '0.5rem',
       height: '25vh',
     },
-  },
-});
-
-export const skeletonWrapper = recipe({
-  base: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    zIndex: 1,
-    transition: 'opacity 0.3s ease',
-  },
-  variants: {
-    isLoaded: {
-      true: {
-        opacity: 0,
-      },
-      false: {
-        opacity: 1,
-      },
-    },
-  },
-  defaultVariants: {
-    isLoaded: false,
   },
 });
 

--- a/packages/notion-to-jsx/src/components/Renderer/components/Block/BlockRenderer.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Block/BlockRenderer.tsx
@@ -39,7 +39,8 @@ type BlockRendererMap = {
  *
  * Props 전달 컨벤션:
  * - children이 있는 블록(Toggle, Table, ColumnList): block 통째 전달 (children 접근 필요)
- * - 그 외: 필요한 데이터만 추출하여 전달
+ * - 텍스트 블록(paragraph, heading): children으로 RichText 전달
+ * - 미디어/콘텐츠 블록: block.[type] 콘텐츠 객체를 전달 (컴포넌트가 내부 구조 처리)
  */
 const blockRenderers: BlockRendererMap = {
   link_preview: (block) => <MemoizedLinkPreview url={block.link_preview.url} />,
@@ -68,40 +69,21 @@ const blockRenderers: BlockRendererMap = {
     </Heading3>
   ),
 
-  code: (block) => (
-    <div>
-      <CodeBlock
-        code={block.code.rich_text.map(rt => rt.plain_text).join('')}
-        language={block.code.language}
-        caption={block.code.caption}
-      />
-    </div>
-  ),
+  code: (block) => <CodeBlock code={block.code} />,
 
   image: (block, isColumn) => (
     <figure>
-      <MemoizedImage
-        src={block.image.file?.url || block.image.external?.url || ''}
-        alt={block.image.caption?.[0]?.plain_text || 'Notion image'}
-        caption={block.image.caption}
-        format={block.image.format}
-        isColumn={isColumn}
-      />
+      <MemoizedImage image={block.image} isColumn={isColumn} />
     </figure>
   ),
 
-  bookmark: (block) => (
-    <MemoizedBookmark
-      url={block.bookmark.url}
-      metadata={block.bookmark.metadata}
-    />
-  ),
+  bookmark: (block) => <MemoizedBookmark bookmark={block.bookmark} />,
 
   column_list: (block) => <ColumnList block={block} />,
 
   column: () => null,
 
-  quote: (block) => <Quote richTexts={block.quote.rich_text} />,
+  quote: (block) => <Quote quote={block.quote} />,
 
   table: (block) => <Table block={block} />,
 
@@ -109,7 +91,7 @@ const blockRenderers: BlockRendererMap = {
 
   video: (block) => <Video video={block.video} />,
 
-  embed: (block) => <Embed url={block.embed.url} caption={block.embed.caption} />,
+  embed: (block) => <Embed embed={block.embed} />,
 };
 
 const BlockRenderer = memo(({ block, isColumn = false }: BlockRendererProps) => {

--- a/packages/notion-to-jsx/src/components/Renderer/components/Bookmark/Bookmark.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Bookmark/Bookmark.tsx
@@ -11,15 +11,17 @@ import {
   favicon,
   urlText,
 } from './styles.css';
-import { OpenGraphData } from './type';
+import type { BookmarkBlock } from 'notion-types';
 import ExternalLink from '../shared/ExternalLink';
 
+type BookmarkData = BookmarkBlock['bookmark'];
+
 export interface BookmarkProps {
-  url: string;
-  metadata?: OpenGraphData;
+  bookmark: BookmarkData;
 }
 
-const Bookmark = ({ url, metadata }: BookmarkProps) => {
+const Bookmark = ({ bookmark }: BookmarkProps) => {
+  const { url, metadata } = bookmark;
   const [isImageBroken, setIsImageBroken] = useState(false);
 
   return (

--- a/packages/notion-to-jsx/src/components/Renderer/components/Caption/Caption.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Caption/Caption.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { RichTextItem } from 'notion-types';
 import { MemoizedRichText } from '../MemoizedComponents';
 import { captionStyle } from './styles.css';
 

--- a/packages/notion-to-jsx/src/components/Renderer/components/Code/CodeBlock.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Code/CodeBlock.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState, useEffect, useMemo, memo } from 'react';
 import { codeBlock } from './styles.css';
 import Prism, { Grammar, Token } from 'prismjs';
 import { Caption } from '../Caption';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { CodeBlock as CodeBlockType } from 'notion-types';
 
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-jsx';
@@ -31,17 +31,20 @@ const renderToken = (token: string | Token, i: number): ReactNode => {
   );
 };
 
+type CodeData = CodeBlockType['code'];
+
 export interface CodeBlockProps {
-  code: string;
-  language: string;
-  caption?: RichTextItem[];
+  code: CodeData;
 }
 
 // Prism.js는 브라우저 환경에서 window.Prism을 설정하여 추가 언어 플러그인을 등록합니다.
 // 이로 인해 서버(Node.js)와 클라이언트(브라우저)에서 토큰화 결과가 달라져
 // SSR 하이드레이션 불일치가 발생합니다. isMounted 패턴으로 클라이언트 마운트 후에만
 // 토큰화를 수행하여 이 문제를 방지합니다.
-const CodeBlock = memo(({ code, language, caption }: CodeBlockProps) => {
+const CodeBlock = memo(({ code }: CodeBlockProps) => {
+  const { rich_text, language, caption } = code;
+  const plainCode = rich_text.map(rt => rt.plain_text).join('');
+
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
@@ -52,18 +55,18 @@ const CodeBlock = memo(({ code, language, caption }: CodeBlockProps) => {
     if (!isMounted) return null;
     const prismLanguage =
       Prism.languages[language] || Prism.languages.plaintext;
-    return Prism.tokenize(code, prismLanguage as Grammar);
-  }, [code, language, isMounted]);
+    return Prism.tokenize(plainCode, prismLanguage as Grammar);
+  }, [plainCode, language, isMounted]);
 
   return (
-    <>
+    <div>
       <pre className={`${codeBlock} language-${language}`} tabIndex={0}>
         <code className={`language-${language}`}>
-          {tokens ? tokens.map((token, i) => renderToken(token, i)) : code}
+          {tokens ? tokens.map((token, i) => renderToken(token, i)) : plainCode}
         </code>
       </pre>
       <Caption caption={caption} />
-    </>
+    </div>
   );
 });
 

--- a/packages/notion-to-jsx/src/components/Renderer/components/Embed/Embed.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Embed/Embed.tsx
@@ -8,14 +8,16 @@ import {
   isAllowedEmbedDomain,
 } from '../../utils/embedUrlParser';
 import { embedIframe } from './styles.css';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { EmbedBlock } from 'notion-types';
+
+type EmbedData = EmbedBlock['embed'];
 
 interface EmbedProps {
-  url: string;
-  caption?: RichTextItem[];
+  embed: EmbedData;
 }
 
-const Embed = memo(({ url, caption }: EmbedProps) => {
+const Embed = memo(({ embed }: EmbedProps) => {
+  const { url, caption } = embed;
 
   if (!isAllowedEmbedDomain(url)) {
     return (

--- a/packages/notion-to-jsx/src/components/Renderer/components/Embed/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Embed/styles.css.ts
@@ -1,8 +1,9 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '../../../../styles/theme.css';
 
 export const embedIframe = style({
   width: '100%',
   aspectRatio: '16 / 9',
   border: 'none',
-  borderRadius: '8px',
+  borderRadius: vars.borderRadius.lg,
 });

--- a/packages/notion-to-jsx/src/components/Renderer/components/Image/Image.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Image/Image.tsx
@@ -5,17 +5,13 @@ import {
   imageStyle,
   skeletonWrapper,
 } from './styles.css';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { ImageBlock } from 'notion-types';
 import Skeleton from '../../../Skeleton';
 import { useImageLoad } from '../../../../hooks/useImageLoad';
+import { CONTENT_MAX_WIDTH_PX } from '../../../../styles/layout';
 
-export interface ImageFormat {
-  block_width?: number;
-  block_height?: number;
-  block_aspect_ratio?: number;
-}
-
-const MAX_WIDTH = 720;
+type ImageData = ImageBlock['image'];
+type ImageFormat = ImageData['format'];
 
 const getWidthStyle = (format?: ImageFormat, isColumn: boolean = false) => {
   if (
@@ -27,7 +23,7 @@ const getWidthStyle = (format?: ImageFormat, isColumn: boolean = false) => {
   }
 
   if (format?.block_width) {
-    return format.block_width > MAX_WIDTH
+    return format.block_width > CONTENT_MAX_WIDTH_PX
       ? '100%'
       : `${format.block_width}px`;
   }
@@ -51,21 +47,17 @@ const getImageTagStyle = (format?: ImageFormat) => {
 };
 
 export interface ImageProps {
-  src: string;
-  alt: string;
-  caption?: RichTextItem[];
-  priority?: boolean;
-  format?: ImageFormat;
+  image: ImageData;
   isColumn?: boolean;
 }
 
 const Image = ({
-  src,
-  alt,
-  caption,
-  format,
+  image,
   isColumn = false,
 }: ImageProps) => {
+  const src = image.file?.url || image.external?.url || '';
+  const alt = image.caption?.[0]?.plain_text || 'Notion image';
+  const { caption, format } = image;
   const { isLoaded, imgRef, handleLoad } = useImageLoad(src);
 
   return (

--- a/packages/notion-to-jsx/src/components/Renderer/components/Image/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Image/styles.css.ts
@@ -52,27 +52,4 @@ export const imageStyle = recipe({
   },
 });
 
-export const skeletonWrapper = recipe({
-  base: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    zIndex: 1,
-    transition: 'opacity 0.3s ease',
-  },
-  variants: {
-    isLoaded: {
-      true: {
-        opacity: 0,
-      },
-      false: {
-        opacity: 1,
-      },
-    },
-  },
-  defaultVariants: {
-    isLoaded: false,
-  },
-});
+export { skeletonWrapper } from '../../../../styles/loadingOverlay.css';

--- a/packages/notion-to-jsx/src/components/Renderer/components/MemoizedComponents.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/MemoizedComponents.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import RichText, { RichTextItem, RichTextProps } from './RichText/RichTexts';
+import type { RichTextItem } from 'notion-types';
+import RichText, { type RichTextProps } from './RichText/RichTexts';
 import { Image, ImageProps } from './Image';
 import Bookmark, { type BookmarkProps } from './Bookmark/Bookmark';
 
@@ -35,24 +36,29 @@ export const MemoizedRichText = memo<RichTextProps>(RichText, (prev, next) => {
 });
 
 export const MemoizedImage = memo<ImageProps>(Image, (prev, next) => {
+  if (prev.isColumn !== next.isColumn) return false;
+
+  const prevImg = prev.image;
+  const nextImg = next.image;
   return (
-    prev.src === next.src &&
-    prev.alt === next.alt &&
-    prev.isColumn === next.isColumn &&
-    prev.format?.block_width === next.format?.block_width &&
-    prev.format?.block_height === next.format?.block_height &&
-    prev.format?.block_aspect_ratio === next.format?.block_aspect_ratio &&
-    areRichTextsEqual(prev.caption, next.caption)
+    prevImg.file?.url === nextImg.file?.url &&
+    prevImg.external?.url === nextImg.external?.url &&
+    prevImg.format?.block_width === nextImg.format?.block_width &&
+    prevImg.format?.block_height === nextImg.format?.block_height &&
+    prevImg.format?.block_aspect_ratio === nextImg.format?.block_aspect_ratio &&
+    areRichTextsEqual(prevImg.caption, nextImg.caption)
   );
 });
 
-// url과 metadata 모두 비교하여 OG 데이터 변경도 감지
+// bookmark 객체의 url과 metadata를 비교하여 OG 데이터 변경도 감지
 export const MemoizedBookmark = memo<BookmarkProps>(Bookmark, (prev, next) => {
+  const prevBm = prev.bookmark;
+  const nextBm = next.bookmark;
   return (
-    prev.url === next.url &&
-    prev.metadata?.title === next.metadata?.title &&
-    prev.metadata?.description === next.metadata?.description &&
-    prev.metadata?.image === next.metadata?.image
+    prevBm.url === nextBm.url &&
+    prevBm.metadata?.title === nextBm.metadata?.title &&
+    prevBm.metadata?.description === nextBm.metadata?.description &&
+    prevBm.metadata?.image === nextBm.metadata?.image
   );
 });
 

--- a/packages/notion-to-jsx/src/components/Renderer/components/Quote/Quote.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Quote/Quote.tsx
@@ -1,17 +1,18 @@
 import { memo } from 'react';
 import { MemoizedRichText } from '../MemoizedComponents';
 import { container } from './styles.css';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { QuoteBlock } from 'notion-types';
+
+type QuoteData = QuoteBlock['quote'];
 
 export interface QuoteProps {
-  richTexts: RichTextItem[];
-  tabIndex?: number;
+  quote: QuoteData;
 }
 
-const Quote = memo(({ richTexts, tabIndex }: QuoteProps) => {
+const Quote = memo(({ quote }: QuoteProps) => {
   return (
-    <blockquote className={container} tabIndex={tabIndex}>
-      <MemoizedRichText richTexts={richTexts} />
+    <blockquote className={container}>
+      <MemoizedRichText richTexts={quote.rich_text} />
     </blockquote>
   );
 });

--- a/packages/notion-to-jsx/src/components/Renderer/components/RichText/RichTexts.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/RichText/RichTexts.tsx
@@ -3,11 +3,10 @@ import type { RichTextItem } from 'notion-types';
 import { richText, link, emptyRichText } from './styles.css';
 import ExternalLink from '../shared/ExternalLink';
 
-export type { RichTextItem };
+type RichTextType = RichTextItem['type'];
 
-const contentRenderers: Record<
-  string,
-  (text: RichTextItem) => ReactNode
+const contentRenderers: Partial<
+  Record<RichTextType, (text: RichTextItem) => ReactNode>
 > = {
   text: (text) => {
     if (text.text) {

--- a/packages/notion-to-jsx/src/components/Renderer/components/Table/Table.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Table/Table.tsx
@@ -3,8 +3,6 @@ import { tableContainer, table, headerCell } from './styles.css';
 import TableRow from './TableRow';
 import { TableBlock } from '../../../../types';
 
-const NO_ROW_HEADER = -1;
-
 interface TableProps {
   block: TableBlock;
 }
@@ -38,7 +36,7 @@ const Table = memo(({ block }: TableProps) => {
             <TableRow
               key={row.id}
               rowBlock={row}
-              rowHeaderIndex={has_row_header ? 0 : NO_ROW_HEADER}
+              rowHeaderIndex={has_row_header ? 0 : null}
             />
           ))}
         </tbody>

--- a/packages/notion-to-jsx/src/components/Renderer/components/Table/TableRow.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Table/TableRow.tsx
@@ -2,19 +2,19 @@ import { memo } from 'react';
 import { tableCell, firstCell, lastCell, hasRowHeader } from './styles.css';
 import { MemoizedRichText } from '../MemoizedComponents';
 import { TableRowBlock } from '../../../../types';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { RichTextItem } from 'notion-types';
 
 interface TableRowProps {
   rowBlock: TableRowBlock;
   cellClassName?: string;
-  rowHeaderIndex?: number;
+  rowHeaderIndex?: number | null;
   isColumnHeader?: boolean;
 }
 
 const TableRow = memo(({
   rowBlock,
   cellClassName = '',
-  rowHeaderIndex = -1,
+  rowHeaderIndex = null,
   isColumnHeader = false,
 }: TableRowProps) => {
   if (!rowBlock.table_row?.cells) {

--- a/packages/notion-to-jsx/src/components/Renderer/components/Video/Video.tsx
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Video/Video.tsx
@@ -5,7 +5,7 @@ import { mediaContainer } from '../shared/styles.css';
 import ExternalLink from '../shared/ExternalLink';
 import { getVideoEmbedUrl } from '../../utils/embedUrlParser';
 import { videoPlayer, nativeVideo } from './styles.css';
-import { RichTextItem } from '../RichText/RichTexts';
+import type { RichTextItem } from 'notion-types';
 
 // ============ 서브 컴포넌트 ============
 

--- a/packages/notion-to-jsx/src/components/Renderer/components/Video/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Renderer/components/Video/styles.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '../../../../styles/theme.css';
 
 export const videoPlayer = style({
   width: '100%',
@@ -9,5 +10,5 @@ export const videoPlayer = style({
 export const nativeVideo = style({
   width: '100%',
   maxWidth: '100%',
-  borderRadius: '8px',
+  borderRadius: vars.borderRadius.lg,
 });

--- a/packages/notion-to-jsx/src/components/Renderer/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Renderer/styles.css.ts
@@ -1,12 +1,13 @@
 import { style } from '@vanilla-extract/css';
 import { vars } from '../../styles/theme.css';
+import { CONTENT_MAX_WIDTH } from '../../styles/layout';
 
 export const container = style({
-  maxWidth: '720px',
+  maxWidth: CONTENT_MAX_WIDTH,
   margin: '0 auto',
   padding: vars.spacing.xl,
   '@media': {
-    '(max-width: 720px)': {
+    [`(max-width: ${CONTENT_MAX_WIDTH})`]: {
       padding: vars.spacing.md,
     },
   },

--- a/packages/notion-to-jsx/src/components/Skeleton/index.tsx
+++ b/packages/notion-to-jsx/src/components/Skeleton/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import * as styles from './styles.css';
+import { skeleton, rect, circle, image } from './styles.css';
 
 type SkeletonProps = {
   /**
@@ -39,12 +39,12 @@ const Skeleton = memo(({
   const getVariantClass = () => {
     switch (variant) {
       case 'circle':
-        return styles.circle;
+        return circle;
       case 'image':
-        return styles.image;
+        return image;
       case 'rect':
       default:
-        return styles.rect;
+        return rect;
     }
   };
 
@@ -54,7 +54,7 @@ const Skeleton = memo(({
 
   return (
     <div
-      className={`${styles.skeleton} ${getVariantClass()} ${className || ''}`}
+      className={`${skeleton} ${getVariantClass()} ${className || ''}`}
       style={{
         width: width || undefined,
         height: height || undefined,

--- a/packages/notion-to-jsx/src/components/Skeleton/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/Skeleton/styles.css.ts
@@ -15,7 +15,7 @@ export const skeleton = style({
   height: '100%',
   width: '100%',
   backgroundColor: vars.colors.skeleton,
-  borderRadius: '4px',
+  borderRadius: vars.borderRadius.sm,
   position: 'relative',
   overflow: 'hidden',
   '::after': {
@@ -36,7 +36,7 @@ export const skeleton = style({
 export const rect = style({
   width: '100%',
   height: '20px',
-  marginBottom: '8px',
+  marginBottom: vars.spacing.sm,
 });
 
 export const circle = style({
@@ -47,5 +47,5 @@ export const circle = style({
 
 export const image = style({
   width: '100%',
-  borderRadius: '8px',
+  borderRadius: vars.borderRadius.lg,
 });

--- a/packages/notion-to-jsx/src/components/TableOfContents/styles.css.ts
+++ b/packages/notion-to-jsx/src/components/TableOfContents/styles.css.ts
@@ -15,13 +15,13 @@ export const linesWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',
-  gap: '12px',
+  gap: vars.spacing.base,
 });
 
 export const line = style({
   height: '3px',
   backgroundColor: vars.colors.border,
-  borderRadius: '6px',
+  borderRadius: vars.borderRadius.md,
 });
 
 export const lineLevel1 = style({
@@ -75,7 +75,7 @@ export const menuLink = style({
   fontSize: vars.typography.fontSize.small,
   lineHeight: 1.4,
   color: vars.colors.secondary,
-  padding: `4px ${vars.spacing.sm}`,
+  padding: `${vars.spacing.xs} ${vars.spacing.sm}`,
   borderRadius: vars.borderRadius.sm,
   whiteSpace: 'nowrap',
   ':hover': {

--- a/packages/notion-to-jsx/src/styles/layout.ts
+++ b/packages/notion-to-jsx/src/styles/layout.ts
@@ -1,0 +1,5 @@
+/** 콘텐츠 영역의 최대 너비 (px 숫자값). Image 등 JS 계산에서 사용 */
+export const CONTENT_MAX_WIDTH_PX = 720;
+
+/** 콘텐츠 영역의 최대 너비 (CSS 문자열). 스타일 파일에서 사용 */
+export const CONTENT_MAX_WIDTH = `${CONTENT_MAX_WIDTH_PX}px`;

--- a/packages/notion-to-jsx/src/styles/loadingOverlay.css.ts
+++ b/packages/notion-to-jsx/src/styles/loadingOverlay.css.ts
@@ -1,0 +1,27 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+/** 이미지 로딩 시 스켈레톤 오버레이용 공통 recipe (Cover, Image에서 공유) */
+export const skeletonWrapper = recipe({
+  base: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: 1,
+    transition: 'opacity 0.3s ease',
+  },
+  variants: {
+    isLoaded: {
+      true: {
+        opacity: 0,
+      },
+      false: {
+        opacity: 1,
+      },
+    },
+  },
+  defaultVariants: {
+    isLoaded: false,
+  },
+});

--- a/packages/notion-to-jsx/src/utils/extractHeadings.ts
+++ b/packages/notion-to-jsx/src/utils/extractHeadings.ts
@@ -23,11 +23,17 @@ const isHeadingBlock = (block: NotionBlock): block is HeadingBlock => {
   return block.type in headingConfig;
 };
 
-type HeadingContent = { rich_text: Array<{ plain_text: string }> };
+const getHeadingContent = (block: HeadingBlock) => {
+  switch (block.type) {
+    case 'heading_1': return block.heading_1;
+    case 'heading_2': return block.heading_2;
+    case 'heading_3': return block.heading_3;
+  }
+};
 
 const extractHeadingData = (block: HeadingBlock) => {
   const level = headingConfig[block.type];
-  const content = block[block.type] as HeadingContent;
+  const content = getHeadingContent(block);
   return {
     text: content.rich_text.map((t) => t.plain_text).join(''),
     level,


### PR DESCRIPTION
## 변경 사항

- **Props 전달 컨벤션 통일**: 미디어/콘텐츠 블록 컴포넌트가 `block.[type]` 콘텐츠 객체를 직접 받도록 통일 (CodeBlock, Image, Bookmark, Embed, Quote)
- **타입 안전성 강화**: LinkPreview 에러 핸들링 개선, Table sentinel value를 `null` 패턴으로 변경, extractHeadings 타입 가드 추가
- **CSS 매직넘버 제거**: `CONTENT_MAX_WIDTH` 상수 추출 및 중복 `skeletonWrapper` 스타일을 공통 모듈로 통합
- **import 정리**: `RichTextItem`을 `notion-types`에서 직접 import, Skeleton 와일드카드 import를 named import으로 변경

## 변경된 파일

- `BlockRenderer.tsx` - Props 전달 컨벤션 통일 (content object 패턴)
- `CodeBlock.tsx`, `Image.tsx`, `Bookmark.tsx`, `Embed.tsx`, `Quote.tsx` - content object Props 수용
- `MemoizedComponents.tsx` - memo comparator를 content object 구조에 맞게 업데이트
- `LinkPreview.tsx` - fetch 에러 핸들링 및 타입 안전성 개선
- `Table.tsx`, `TableRow.tsx` - sentinel value `-1` → `null` 패턴
- `extractHeadings.ts` - 타입 가드 추가
- `styles/layout.ts` - CONTENT_MAX_WIDTH 상수 추출
- `styles/loadingOverlay.css.ts` - 공통 skeletonWrapper 스타일 추출
- 기타 스타일/import 정리 파일들

## 테스트

- [x] `pnpm build` 성공
- [x] `pnpm test` 52개 테스트 통과
- [x] 모든 변경은 내부 컴포넌트 Props만 수정 (public API 변경 없음)